### PR TITLE
Fix: supabase.js Window Error

### DIFF
--- a/src/utils/supabase.ts
+++ b/src/utils/supabase.ts
@@ -1,5 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { createClient } from '@supabase/supabase-js';
+import { Platform } from 'react-native'; // import to fix
 
 const supabaseUrl = 'https://kyylulozmjvnznbrsyfg.supabase.co';
 const supabaseAnonKey =
@@ -7,7 +8,7 @@ const supabaseAnonKey =
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
   auth: {
-    storage: AsyncStorage,
+    ...(Platform.OS !== "web" ? { storage: AsyncStorage } : {}), // fix: https://github.com/supabase/supabase-js/issues/870 other fixes: https://github.com/orgs/supabase/discussions/25909
     autoRefreshToken: true,
     persistSession: true,
     detectSessionInUrl: false,


### PR DESCRIPTION
Fixes the "ReferenceError: window is not defined" error when trying to run the app on web.

Resolves the issue of the web version not connecting to the server as async storage is not being compatible with the web (some bug).